### PR TITLE
Host MTProxy

### DIFF
--- a/hosts/galapagos/services/default.nix
+++ b/hosts/galapagos/services/default.nix
@@ -8,5 +8,6 @@
     ./onlyoffice.nix
     # ./plausible.nix
     ./website.nix
+    ./mtproxy.nix
   ];
 }

--- a/hosts/galapagos/services/mtproxy.nix
+++ b/hosts/galapagos/services/mtproxy.nix
@@ -1,0 +1,26 @@
+{ config, ... }:
+
+let
+  port = 4967;
+in
+{
+  services.mtprotoproxy = {
+    enable = true;
+    adTag = "dec9fe76d73a6fa57810e25eeff9a077";
+    users = {
+      tg = "11653fccf4b4145650fcf7293a9df7a8";
+    };
+    extraConfig = {
+      MODES = {
+        classic = false;
+        secure = true;
+        tls = true;
+      };
+      TLS_DOMAIN = "gelos.club";
+    };
+    inherit port;
+  };
+
+  networking.firewall.allowedTCPPorts = [ port ];
+
+}


### PR DESCRIPTION
Adicionei aí o MTProxy, do Telegram, pra comunidade do ICMC não ficar prejudicada qnd houver bloqueios.

Pra usar é só abrir esse [link](tg://proxy?server=gelos.club&port=4967&secret=dd11653fccf4b4145650fcf7293a9df7a8) no Telegram