### PR TITLE
Remove nix cache action from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: determinatesystems/nix-installer-action@v4
-      - uses: determinatesystems/magic-nix-cache-action@v2
       - env:
           NIXOS_CONFIG: ${{ matrix.system }}
         run: |


### PR DESCRIPTION
It keeps getting ratelimited and taking a significant amount of the workflow execution time